### PR TITLE
Add ping chart

### DIFF
--- a/speedtest/scripts/init_test_connection.sh
+++ b/speedtest/scripts/init_test_connection.sh
@@ -9,9 +9,12 @@ do
 
 	DOWNLOAD=$(cat $FILE | grep "Download:" | awk -F " " '{print $2}')
 	UPLOAD=$(cat $FILE | grep "Upload:" | awk -F " " '{print $2}')
-	echo "Download: $DOWNLOAD Upload: $UPLOAD    $TIMESTAMP"
+	PING=$(ping -qc1 google.com 2>&1 | awk -F'/' 'END{ print (/^round-trip/? $4:"-100") }')
+	echo "Ping: $PING   $TIMESTAMP"
+	echo "Download: $DOWNLOAD Upload: $UPLOAD Ping: $PING   $TIMESTAMP"
 	curl -i -XPOST 'http://db:8086/write?db=speedtest' --data-binary "download,host=local value=$DOWNLOAD"
 	curl -i -XPOST 'http://db:8086/write?db=speedtest' --data-binary "upload,host=local value=$UPLOAD"
+	curl -i -XPOST 'http://db:8086/write?db=speedtest' --data-binary "ping,host=local value=$PING"
 	sleep $TEST_INTERVAL
 
 done

--- a/speedweb/conf/home.json
+++ b/speedweb/conf/home.json
@@ -250,6 +250,127 @@
       "title": "Row",
       "collapse": false,
       "editable": true
+    },
+    {
+      "height": "610px",
+      "panels": [
+        {
+          "title": "Ping",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "yaxes": [
+            {
+              "show": true,
+              "min": null,
+              "max": null,
+              "logBase": 1,
+              "format": "ms"
+            },
+            {
+              "show": true,
+              "min": null,
+              "max": null,
+              "logBase": 1,
+              "format": "ms"
+            }
+          ],
+          "isNew": true,
+          "id": 3,
+          "datasource": "InfluxDB",
+          "renderer": "flot",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "ms",
+            "ms"
+          ],
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "rightMax": null,
+            "leftMin": null,
+            "rightMin": null,
+            "rightLogBase": 1,
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "targets": [
+            {
+              "refId": "A",
+              "dsType": "influxdb",
+              "resultFormat": "time_series",
+              "tags": [],
+              "groupBy": [
+                {
+                  "type": "time",
+                  "params": [
+                    "$interval"
+                  ]
+                },
+                {
+                  "type": "fill",
+                  "params": [
+                    "null"
+                  ]
+                }
+              ],
+              "select": [
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "value"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  }
+                ]
+              ],
+              "alias": "Ping",
+              "measurement": "ping",
+              "query": "SELECT mean(\"value\") FROM \"ping\" WHERE $timeFilter GROUP BY time($interval) fill(null)"
+            }
+          ],
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": [],
+          "height": "250px"
+        }
+      ],
+      "title": "Row",
+      "collapse": false,
+      "editable": true
     }
   ],
   "time": {
@@ -260,6 +381,8 @@
     "enable": false,
     "type": "timepicker",
     "time_options": [
+      "30s",
+      "1m",
       "5m",
       "15m",
       "1h",


### PR DESCRIPTION
Fixes https://github.com/pedrocesar-ti/internet-speedtest-docker/issues/18 by adding a ping script along with a new row in the grafana dashboard.
For failed pings e.g. due to a network disconnection the value '-100' is assumed to easily detect connection disruptures in the graph.